### PR TITLE
Avoid unresponsive ui during DashWait

### DIFF
--- a/ModronGUI.ahk
+++ b/ModronGUI.ahk
@@ -715,6 +715,7 @@ DoDashWait()
         StuffToSpam(0, 1, 0)
         ElapsedTime := UpdateElapsedTime(StartTime)
         UpdateStatTimers()
+        Sleep, 100
     }
     if (ReadQuestRemaining(1))
     FinishZone()

--- a/ModronGUI.ahk
+++ b/ModronGUI.ahk
@@ -715,7 +715,9 @@ DoDashWait()
         StuffToSpam(0, 1, 0)
         ElapsedTime := UpdateElapsedTime(StartTime)
         UpdateStatTimers()
-        Sleep, 100
+        ; without fkey or click leveling, this turns to busy loopi
+        ; and freezes script ui. Fix is by small sleep
+        Sleep, 10
     }
     if (ReadQuestRemaining(1))
     FinishZone()


### PR DESCRIPTION
When using `DoDashWait` without fkey leveling or click leveling, the while loop becomes a busy wait that makes the script ui unresponsive.

`StuffToSpam(0, 1, 0)` does not seem to sleep if clickleveling is off