### PR TITLE
Conservative FailStackRecovery

### DIFF
--- a/ModronGUI.ahk
+++ b/ModronGUI.ahk
@@ -1209,7 +1209,17 @@ GemFarm()
             StackFarm()
         }
 
-        if (gStackCountH < 50 AND gLevel_Number > gMinStackZone AND gStackFailRecovery AND gLevel_Number < gAreaLow)
+        if (gStackCountH < 50 AND stacks < gSBTargetStacks AND gStackFailRecovery AND gLevel_Number > gAreaLow - 10)
+        {
+            ; We're out of haste stacks less than 10 levels from the usual
+            ; stacking level, so let's just finish the run with a normal modron
+            ; reset instead of trying to Complete Adventure.
+            ; This can happen if you don't build in a buffer in your target
+            ; haste stacks, but it's better to just go through a
+            ; few levels without briv skip than to force a restart.
+            GuiControl, MyWindow:, gloopID, Slog to Modron Reset
+        }
+        else if (gStackCountH < 50 AND gLevel_Number > gMinStackZone AND gStackFailRecovery AND gLevel_Number < gAreaLow)
         {
             if (gStackCountSB < gSBTargetStacks)
             {


### PR DESCRIPTION
I find that it's better to just finish out a run normally than to force a second restart, if we only have a few levels to go until the regular modron reset.  This is obviously slower than if I had haste stacks, but faster than an extra restart of IC.  I suspect that users do one of two things:

1.  Put the modron reset level into https://ic.byteglow.com/speed .  If you do this, you're building in a natural buffer, because the script only runs until `gAreaLow`, not the modron reset level.  You'll FailStackRecovery fairly infrequently, but might be able to eke out a little more bph if you lowered your target haste stacks (`gSBTargetStacks`).
2. Put gAreaLow into https://ic.byteglow.com/speed .  If you do this, then you're going to be short a little less than half of the time. and FailStackRecovery somewhat often.   If you *then* put some BSCs into Briv, you'll then stabilize into infrequent FailStackRecovery.

## What changes? 
Assume my settings are to `StackRestart` at level 444 and Modron reset at 450

### Current behavior
I will abort at 443 if I hit 49 stacks, restarting once for stacks, and a second time to restart the adventure.

### New behavior
I will abort at 433 if I hit 49 stacks, restarting once for stacks, and a second time to restart the adventure.
I will remain in `q` formation from 433 to 444 even if I have no haste stacks, and then perform a regular `StackRestart` and modron reset.

### Why?
The new behavior allows me to be more aggressive with target haste stacks, allowing me to undershoot more often without as big of an impact.  With this change, I use `gAreaLow` as my target level in https://ic.byteglow.com/speed , not my modron reset level.

The 10 level buffer was chosen arbitrarily.