### PR TITLE
Do as little work as possible during offline calculations

### DIFF
--- a/SharedFunctions/IC_SharedFunctions_Class.ahk
+++ b/SharedFunctions/IC_SharedFunctions_Class.ahk
@@ -607,6 +607,7 @@ class IC_SharedFunctions_Class
             g_SharedData.LoopString := "Waiting for offline progress.."
             while( ElapsedTime < timeout AND !this.Memory.ReadOfflineDone())
             {
+                Sleep, 250
                 ElapsedTime := A_TickCount - timeoutTimerStart
             }
             ; finished before timeout


### PR DESCRIPTION
Busy waits affect offline stack calculations.  Without this sleep, I get 20% fewer offline stacks.
