### PR TITLE
show previous stack counts while IC is closed

### DIFF
--- a/AddOns/IC_BrivGemFarm_Performance/IC_BrivGemFarm_Functions.ahk
+++ b/AddOns/IC_BrivGemFarm_Performance/IC_BrivGemFarm_Functions.ahk
@@ -230,6 +230,8 @@ class IC_BrivGemFarm_Class
         static previousLoopStartTime := A_TickCount
         static lastZone := -1
         static lastResetCount := 0
+        static sbStackMessage := ""
+        static hasteStackMessage := ""
 
         Critical, On
         currentZone := g_SF.Memory.ReadCurrentZone()
@@ -248,8 +250,28 @@ class IC_BrivGemFarm_Class
             lastZone := currentZone
         }
 
-        GuiControl, ICScriptHub:, g_StackCountSBID, % g_SF.Memory.ReadSBStacks()
-        GuiControl, ICScriptHub:, g_StackCountHID, % g_SF.Memory.ReadHasteStacks()
+        sbStacks := g_SF.Memory.ReadSBStacks()
+        if (sbStacks == "")
+        {
+            if (SubStr(sbStackMessage, 1, 1) != "[")
+            {
+                sbStackMessage := "[" . sbStackMessage . "] last seen"
+            }
+        } else {
+            sbStackMessage := sbStacks
+        }
+        hasteStacks := g_SF.Memory.ReadHasteStacks()
+        if (hasteStacks == "")
+        {
+            if (SubStr(hasteStackMessage, 1, 1) != "[")
+            {
+                hasteStackMessage := "[" . hasteStackMessage . "] last seen"
+            }
+        } else {
+            hasteStackMessage := hasteStacks
+        }
+        GuiControl, ICScriptHub:, g_StackCountSBID, % sbStackMessage
+        GuiControl, ICScriptHub:, g_StackCountHID, % hasteStackMessage
 
         ;dtCurrentRunTime := Round( ( A_TickCount - g_RunStartTime ) / 60000, 2 )
         dtCurrentRunTime := Round( ( A_TickCount - previousLoopStartTime ) / 60000, 2 )

--- a/ICScriptHub.ahk
+++ b/ICScriptHub.ahk
@@ -109,9 +109,9 @@ Gui, ICScriptHub:Add, Text, x%g_LeftAlign% y+2, Current `Run Time (min):
 Gui, ICScriptHub:Add, Text, vdtCurrentRunTimeID x+2 w50, % dtCurrentRunTime
 
 Gui, ICScriptHub:Add, Text, x%g_LeftAlign% y+10, SB Stack `Count:
-Gui, ICScriptHub:Add, Text, vg_StackCountSBID x+2 w50, % g_StackCountSB
+Gui, ICScriptHub:Add, Text, vg_StackCountSBID x+2 w100, % g_StackCountSB
 Gui, ICScriptHub:Add, Text, x%g_LeftAlign% y+2, Haste Stack `Count:
-Gui, ICScriptHub:Add, Text, vg_StackCountHID x+2 w50, % g_StackCountH
+Gui, ICScriptHub:Add, Text, vg_StackCountHID x+2 w100, % g_StackCountH
 
 ; Gui, ICScriptHub:Add, Text, x15 y+10, Inputs Sent:
 ; Gui, ICScriptHub:Add, Text, vg_InputsSentID x+2 w50, % g_InputsSent


### PR DESCRIPTION
see how many stacks you had right before IC closed.  Will preserve the stale stack values until new ones can be read.

<img width="510" alt="Screen Shot 2022-01-09 at 4 19 54 PM" src="https://user-images.githubusercontent.com/4175579/148707180-96e8823d-556d-42c7-9049-db64ca4f392e.png">
