### PR TITLE
Run ahk command

### DIFF
--- a/AddOns/IC_BrivGemFarm_Performance/IC_BrivGemFarm_Component.ahk
+++ b/AddOns/IC_BrivGemFarm_Performance/IC_BrivGemFarm_Component.ahk
@@ -102,7 +102,7 @@ Briv_Run_Clicked()
     scriptLocation := A_LineFile . "\..\IC_BrivGemFarm_Run.ahk"
     GuiControl, Choose, ModronTabControl, Stats
     g_BrivFarm.StartTimedFunctions()
-    Run, %A_AhkPath% %scriptLocation%
+    Run, %A_AhkPath% "%scriptLocation%"
 }
 
 Briv_Run_Stop_Clicked()

--- a/AddOns/IC_BrivGemFarm_Performance/IC_BrivGemFarm_Component.ahk
+++ b/AddOns/IC_BrivGemFarm_Performance/IC_BrivGemFarm_Component.ahk
@@ -102,7 +102,7 @@ Briv_Run_Clicked()
     scriptLocation := A_LineFile . "\..\IC_BrivGemFarm_Run.ahk"
     GuiControl, Choose, ModronTabControl, Stats
     g_BrivFarm.StartTimedFunctions()
-    Run, %scriptLocation%
+    Run, %A_AhkPath% %scriptLocation%
 }
 
 Briv_Run_Stop_Clicked()


### PR DESCRIPTION
Solution for issue: brivGemFarm will not load if AHK is not the default file association in windows.
as provided by the user