### PR TITLE
Always turn off Critical after turning it on

### DIFF
--- a/AddOns/IC_BrivGemFarm_Performance/IC_BrivGemFarm_Functions.ahk
+++ b/AddOns/IC_BrivGemFarm_Performance/IC_BrivGemFarm_Functions.ahk
@@ -754,8 +754,10 @@ class IC_BrivGemFarm_Class
     {
         Critical, On
         if(g_SF.ShouldSkipSwap() AND !(g_BrivUserSettings[ "AvoidBosses" ] AND Mod( g_SF.Memory.ReadHighestZone(), 5 ) == 0))
+        {
             Critical, Off
             return
+        }
         StartTime := A_TickCount
         ElapsedTime := counter := 0
         sleepTime := 68

--- a/AddOns/IC_BrivGemFarm_Performance/IC_BrivGemFarm_Functions.ahk
+++ b/AddOns/IC_BrivGemFarm_Performance/IC_BrivGemFarm_Functions.ahk
@@ -359,7 +359,9 @@ class IC_BrivGemFarm_Class
         {
             while(!g_SF.Memory.ReadOfflineDone() AND IsObject(SharedRunData) AND SharedRunData.TriggerStart)
             {
+                Critical, Off
                 Sleep, 50
+                Critical, On
             }
             ; CoreXP starting on FRESH run.
             if(!TotalRunCount)
@@ -752,6 +754,7 @@ class IC_BrivGemFarm_Class
     {
         Critical, On
         if(g_SF.ShouldSkipSwap() AND !(g_BrivUserSettings[ "AvoidBosses" ] AND Mod( g_SF.Memory.ReadHighestZone(), 5 ) == 0))
+            Critical, Off
             return
         StartTime := A_TickCount
         ElapsedTime := counter := 0
@@ -776,6 +779,7 @@ class IC_BrivGemFarm_Class
         ; Don't swap to Briv if current highest zone is a boss zone.
         if ( g_BrivUserSettings[ "AvoidBosses" ] AND Mod( g_SF.Memory.ReadHighestZone(), 5 ) == 0 )
         {
+            Critical, Off
             return
         }
         StartTime := A_TickCount

--- a/SharedFunctions/IC_SharedFunctions_Class.ahk
+++ b/SharedFunctions/IC_SharedFunctions_Class.ahk
@@ -818,9 +818,11 @@ class IC_SharedFunctions_Class
         counter := 0
         sleepTime := 34
         seat := this.Memory.ReadChampSeatByID(ChampID)
-        if(seat < 0)
+        if ( seat < 0 )
+        {
             Critical, Off
             return
+        }
         var := ["{F" . seat . "}"]
         if( IsObject(keys) )
             var.Push(keys*)

--- a/SharedFunctions/IC_SharedFunctions_Class.ahk
+++ b/SharedFunctions/IC_SharedFunctions_Class.ahk
@@ -72,7 +72,7 @@ class IC_SharedFunctions_Class
     ; returns this class's version information (string)
     GetVersion()
     {
-        return "v2.4, 01/10/2022"
+        return "v2.4, 2022-01-10"
     }
 
     ;Gets data from JSON file
@@ -819,6 +819,7 @@ class IC_SharedFunctions_Class
         sleepTime := 34
         seat := this.Memory.ReadChampSeatByID(ChampID)
         if(seat < 0)
+            Critical, Off
             return
         var := ["{F" . seat . "}"]
         if( IsObject(keys) )


### PR DESCRIPTION
I finally tracked down the real reason why my GUI goes unresponsive for 30 seconds at a time when I need it most during restart:   Some of the functions turn on Critical, and then short-circuit return without turning it off.