### PR TITLE
Fix call to IsCurrentFormation

### DIFF
--- a/AddOns/IC_BrivGemFarm_Performance/IC_BrivGemFarm_Functions.ahk
+++ b/AddOns/IC_BrivGemFarm_Performance/IC_BrivGemFarm_Functions.ahk
@@ -719,7 +719,7 @@ class IC_BrivGemFarm_Class
         highestZone := g_SF.Memory.ReadHighestZone()
         if(g_SF.Memory.ReadChampLvlByID( 58 ) < 170) ; briv doesn't have jump+specialization yet - do setup stuff first
             return
-        isJumpFormation := g_SF.Memory.IsCurrentFormation(g_SF.Memory.GetFormationByFavorite( 1 ) )
+        isJumpFormation := g_SF.IsCurrentFormation(g_SF.Memory.GetFormationByFavorite( 1 ) )
         ; Level complete, moving to next area.
         if ( !g_SF.Memory.ReadQuestRemaining() AND g_SF.Memory.ReadTransitioning() )  ; Important! Need both reads or swaps won't happen once per jump!
         {


### PR DESCRIPTION
Fix function call.  Now that I can post messages to the GUI, I can see that isJumpFormation is always null.

IsCurrentFormation is in IC_SharedFunctions_Class not IC_MemoryFunctions_Class.