### PR TITLE
Fixed references to readme.md so they are Readme.md

### DIFF
--- a/docfiles/an-introduction-to-ic-script-hub.md
+++ b/docfiles/an-introduction-to-ic-script-hub.md
@@ -1,4 +1,4 @@
-[< Return to the Readme](../readme.md)
+[< Return to the Readme](../Readme.md)
 
 # Exploring IC Script Hub
 ## Overview

--- a/docfiles/getting-started-with-ic-script-hub-using-git.md
+++ b/docfiles/getting-started-with-ic-script-hub-using-git.md
@@ -1,4 +1,4 @@
-[< Return to the Readme](../readme.md)
+[< Return to the Readme](../Readme.md)
 
 # Getting started with IC Script Hub using Git
 ## Introduction

--- a/docfiles/getting-started-with-ic-script-hub-using-zip.md
+++ b/docfiles/getting-started-with-ic-script-hub-using-zip.md
@@ -1,4 +1,4 @@
-[< Return to the Readme](../readme.md)
+[< Return to the Readme](../Readme.md)
 
 # Getting started with IC Script Hub using Zip
 ## What we'll cover

--- a/docfiles/using-ic-script-hub-with-egs.md
+++ b/docfiles/using-ic-script-hub-with-egs.md
@@ -1,4 +1,4 @@
-[< Return to the Readme](../readme.md)
+[< Return to the Readme](../Readme.md)
 
 # Setting Idle Champions game location for EGS
 

--- a/docfiles/using-ic-script-hub-with-steam.md
+++ b/docfiles/using-ic-script-hub-with-steam.md
@@ -1,4 +1,4 @@
-[< Return to the Readme](../readme.md)
+[< Return to the Readme](../Readme.md)
 
 # Setting Idle Champions game location for Steam
 


### PR DESCRIPTION
To account for Linux case sensitivity when viewing documentation via GitHub.