### PR TITLE
add shandie to briv party setup spam

### DIFF
--- a/AddOns/IC_BrivGemFarm_Performance/IC_BrivGemFarm_Functions.ahk
+++ b/AddOns/IC_BrivGemFarm_Performance/IC_BrivGemFarm_Functions.ahk
@@ -671,9 +671,16 @@ class IC_BrivGemFarm_Class
     {
         formationFavorite1 := g_SF.Memory.GetFormationByFavorite( 1 )
         isShandieInFormation := g_SF.IsChampInFormation( 47, formationFavorite1 )
-        g_SF.LevelChampByID( 58, 170, 7000, "{q}") ; level briv
+        brivSpam := ["{q}"]
         if(isShandieInFormation)
+        {
+            brivSpam.push("{F6}")
+        }
+        g_SF.LevelChampByID( 58, 170, 7000, brivSpam) ; level briv first, but also shandie to start dash timer ASAP
+        if(isShandieInFormation)
+        {
             g_SF.LevelChampByID( 47, 230, 7000, "{q}") ; level shandie
+        }
         isHavilarInFormation := g_SF.IsChampInFormation( 56, formationFavorite1 )
         if(isHavilarInFormation)
         {


### PR DESCRIPTION
Briv was put before Shandie so that we don't accidentally complete z1 before he has jump.  This has the side effect of slowing down when dash starts.

Let's add `{F6}` alongside `q` to the keys to spam while levelling Briv, if Shandie is in formation, in order to get the dash timer started a couple of seconds sooner.