### PR TITLE
order of operations

### DIFF
--- a/SharedFunctions/IC_SharedFunctions_Class.ahk
+++ b/SharedFunctions/IC_SharedFunctions_Class.ahk
@@ -812,7 +812,7 @@ class IC_SharedFunctions_Class
         ;spam.Push(this.GetFormationFKeys(formationFavorite1)*) ; make sure champions are leveled
         ;;;if ( this.Memory.ReadNumAttackingMonstersReached() OR this.Memory.ReadNumRangedAttackingMonsters() )
             g_SharedData.LoopString := "Under attack. Retreating to change formations..."
-        while(!IsCurrentFormation AND (this.Memory.ReadNumAttackingMonstersReached() OR this.Memory.ReadNumRangedAttackingMonsters()) AND ElapsedTime < 2 * timeout)
+        while(!IsCurrentFormation AND (this.Memory.ReadNumAttackingMonstersReached() OR this.Memory.ReadNumRangedAttackingMonsters()) AND (ElapsedTime < 2 * timeout))
         {
             ElapsedTime := A_TickCount - StartTime
             this.FallBackFromZone()


### PR DESCRIPTION
The order of operations in AHK when it comes to logical boolean operators is not intuitive to me.
AFAIK, they don't go last and have equal precedence with "<", which can result in a bunch of unexpected behavior.