### PR TITLE
FAILED_TO_RESET_MODRON cleanup

### DIFF
--- a/AddOns/IC_BrivGemFarm_Performance/IC_BrivGemFarm_Functions.ahk
+++ b/AddOns/IC_BrivGemFarm_Performance/IC_BrivGemFarm_Functions.ahk
@@ -381,10 +381,17 @@ class IC_BrivGemFarm_Class
             PreviousRunTime := round( ( A_TickCount - RunStartTime ) / 60000, 2 )
             GuiControl, ICScriptHub:, PrevRunTimeID, % PreviousRunTime
 
-            if ( SlowRunTime < PreviousRunTime AND !StackFail AND TotalRunCount )
-                GuiControl, ICScriptHub:, SlowRunTimeID, % SlowRunTime := PreviousRunTime
-            if ( FastRunTime > PreviousRunTime AND !StackFail AND TotalRunCount )
-                GuiControl, ICScriptHub:, FastRunTimeID, % FastRunTime := PreviousRunTime
+            if ( (TotalRunCount > 1) AND (Stackfail In [0, 6]) )
+            {
+                if ( SlowRunTime < PreviousRunTime)
+                {
+                    GuiControl, ICScriptHub:, SlowRunTimeID, % SlowRunTime := PreviousRunTime
+                }
+                if ( FastRunTime > PreviousRunTime)
+                {
+                    GuiControl, ICScriptHub:, FastRunTimeID, % FastRunTime := PreviousRunTime
+                }
+            }
             if ( StackFail ) ; 1 = Did not make it to Stack Zone. 2 = Stacks did not convert. 3 = Game got stuck in adventure and restarted.
             {
                 GuiControl, ICScriptHub:, FailRunTimeID, % PreviousRunTime

--- a/AddOns/IC_BrivGemFarm_Performance/IC_BrivGemFarm_Functions.ahk
+++ b/AddOns/IC_BrivGemFarm_Performance/IC_BrivGemFarm_Functions.ahk
@@ -472,20 +472,20 @@ class IC_BrivGemFarm_Class
             g_SharedData.StackFailStats.TALLY[stackfail] += 1
             this.StackFarm()
         }
+        ; stacks are more than the target stacks and party is more than 25 levels past stack zone, restart adventure
+        ; (for restarting after stacking without going to modron reset level)
+        else if ( stacks > g_BrivUserSettings[ "TargetStacks" ] AND CurrentZone > g_BrivUserSettings[ "StackZone" ] + g_BrivUserSettings["ResetZoneBuffer"])
+        {
+            stackFail := StackFailStates.FAILED_TO_RESET_MODRON
+            g_SharedData.StackFailStats.TALLY[stackfail] += 1
+            g_SF.RestartAdventure(" Stacks > target stacks & party > " . g_BrivUserSettings["ResetZoneBuffer"] . " levels past stack zone")
+        }
         ; Briv ran out of jumps but has enough stacks for a new adventure, restart adventure
         else if ( g_SF.Memory.ReadHasteStacks() < 50 AND stacks > g_BrivUserSettings[ "TargetStacks" ] AND g_SF.Memory.ReadHighestZone() > 10)
         {
             stackFail := StackFailStates.FAILED_TO_REACH_STACK_ZONE_HARD
             g_SharedData.StackFailStats.TALLY[stackfail] += 1
             g_SF.RestartAdventure( "Briv ran out of jumps but has enough stacks for a new adventure" )
-        }
-        ; stacks are more than the target stacks and party is more than 25 levels past stack zone, restart adventure
-        ; (for restarting after stacking without going to modron reset level)
-        if ( stacks > g_BrivUserSettings[ "TargetStacks" ] AND CurrentZone > g_BrivUserSettings[ "StackZone" ] + g_BrivUserSettings["ResetZoneBuffer"])
-        {
-            stackFail := StackFailStates.FAILED_TO_RESET_MODRON
-            g_SharedData.StackFailStats.TALLY[stackfail] += 1
-            g_SF.RestartAdventure(" Stacks > target stacks & party > " . g_BrivUserSettings["ResetZoneBuffer"] . " levels past stack zone")
         }
         return stackfail
     }


### PR DESCRIPTION
Some general improvements for FAILED_TO_RESET_MODRON stats e.g. temporal rift

* Ignore the first run when updating slowest/fastest run, it's frequently a partial run of some sort.
* If a run is FAILED_TO_RESET_MODRON, allow it to count towards the slowest/fastest run
* If FAILED_TO_RESET_MODRON and FAILED_TO_REACH_STACK_ZONE_HARD happen at the same time, treat the run as a FAILED_TO_RESET_MODRON