### PR TITLE
GetNumStacksFarmed logic change for early stackers

### DIFF
--- a/AddOns/IC_BrivGemFarm_Performance/IC_BrivGemFarm_Functions.ahk
+++ b/AddOns/IC_BrivGemFarm_Performance/IC_BrivGemFarm_Functions.ahk
@@ -487,19 +487,21 @@ class IC_BrivGemFarm_Class
     ;Gets total of SteelBonesStacks + Haste Stacks
     GetNumStacksFarmed()
     {
-        if ( g_BrivUserSettings[ "RestartStackTime" ] )
+        ; to accomodate early stacking:
+        ; Ignore haste stacks if we are past stack zone, like online stacking
+        ; There is a point during modron reset where we have reset current zone, but not converted stacks, so after modron reset level we count both stacks.
+        currentZone := g_SF.Memory.ReadCurrentZone()
+        sbStacks := g_SF.Memory.ReadSBStacks()
+        if ( g_BrivUserSettings[ "RestartStackTime" ] AND ((currentZone < g_BrivUserSettings[ "StackZone" ]) OR (currentZone >= g_SF.ModronResetZone)))
         {
-            return g_SF.Memory.ReadHasteStacks() + g_SF.Memory.ReadSBStacks()
+            return sbStacks + g_SF.Memory.ReadHasteStacks()
         }
         else
         {
-            ; If restart stacking is disabled, we'll stack to basically the exact
-            ; threshold.  That means that doing a single jump would cause you to
-            ; lose stacks to fall below the threshold, which would mean StackNormal
-            ; would happen after every jump.
-            ; Thus, we use a static 47 instead of using the actual haste stacks
+            ; Stack to basically the exact threshold, ignoring current haste stacks.
+            ; We use a static 47 instead of using the actual haste stacks
             ; with the assumption that we'll be at minimum stacks after a reset.
-            return g_SF.Memory.ReadSBStacks() + 47
+            return sbStacks + 47
         }
     }
 


### PR DESCRIPTION
Update logic for counting stacks:  In general, we want to count just the steelbones stacks + 47, not all stacks.  Online stacking already works this way.

This changes the logic so that haste stacks only count towards the total before StackLevel, and on or after modron reset zone.  The latter is needed, because occasionally the game will convert stacks so that you have no steelbones stacks, but still report being at modron reset zone.