### PR TITLE
show estimate with no buffer for DashWait

### DIFF
--- a/SharedFunctions/IC_SharedFunctions_Class.ahk
+++ b/SharedFunctions/IC_SharedFunctions_Class.ahk
@@ -402,6 +402,7 @@ class IC_SharedFunctions_Class
         timeScale := this.Memory.ReadTimeScaleMultiplier()
         timeScale := timeScale < 1 ? 1 : timeScale ; time scale should never be less than 1
         timeout := 80000 / timeScale ; 80 seconds / timescale (8s at 10x)
+        estimate := (60000 / timeScale) ; no buffer: 60s / timescale to show in LoopString
         ; Loop escape conditions:
         ;   does full timeout duration
         ;   past highest accepted dashwait triggering area
@@ -412,7 +413,7 @@ class IC_SharedFunctions_Class
             if !(this.SafetyCheck()) OR !(dash.IsBaseAddressCorrect())
                 dash.Initialize()
             ElapsedTime := A_TickCount - StartTime
-            g_SharedData.LoopString := "Dash Wait: " . ElapsedTime . " / " . timeout
+            g_SharedData.LoopString := "Dash Wait: " . ElapsedTime . " / " . estimate
         }
         g_PreviousZoneStartTime := A_TickCount
         return


### PR DESCRIPTION
The buffer in the `80s / timescale` loop makes sense, but users are perceiving the visible buffer in the LoopString as an error.  Calculate an estimated dashwait with no buffer, and use that for the visible message.