### PR TITLE
fail faster when steam doesn't connect

### DIFF
--- a/AddOns/IC_BrivGemFarm_Potato/IC_BrivGemFarm_Functions.ahk
+++ b/AddOns/IC_BrivGemFarm_Potato/IC_BrivGemFarm_Functions.ahk
@@ -11,6 +11,10 @@ class IC_BrivPotatoSharedFunctions_Class extends IC_BrivSharedFunctions_Class
         {
             ElapsedTime := A_TickCount - timeoutTimerStart
         }
+        if (!this.Memory.ReadGameStarted())
+        {
+            return false
+        }
         ; check if game has offline progress to calculate
         offlineTime := this.Memory.ReadOfflineTime()
         If(offlineTime <= 0 AND offlineTime != "")

--- a/SharedFunctions/IC_SharedFunctions_Class.ahk
+++ b/SharedFunctions/IC_SharedFunctions_Class.ahk
@@ -666,6 +666,10 @@ class IC_SharedFunctions_Class
             this.Memory.OpenProcessReader()
             loadingZone := this.WaitForGameReady()
             this.ResetServerCall()
+            if (!loadingZone)
+            {
+                return -1
+            }
         }
         if(ElapsedTime >= 30000)
             return -1 ; took too long to open

--- a/SharedFunctions/IC_SharedFunctions_Class.ahk
+++ b/SharedFunctions/IC_SharedFunctions_Class.ahk
@@ -684,6 +684,10 @@ class IC_SharedFunctions_Class
         {
             ElapsedTime := A_TickCount - timeoutTimerStart
         }
+        if (!this.Memory.ReadGameStarted())
+        {
+            return false
+        }
         ; check if game has offline progress to calculate
         offlineTime := this.Memory.ReadOfflineTime()
         If(offlineTime <= 0 AND offlineTime != "")


### PR DESCRIPTION
I was able to finally catch the "Could not Connect to Steam" error in action.  It does not loop indefinitely without restart.  However, it takes about 4 minutes for `WaitForGameReady` and then `CheckIfStuck` to finally decide that the game needs to be restarted.  This could all be avoided if `WaitForGameReady` returned failure if it was never `ReadGameStarted`.

PS - `OpenIC` never calculates elapsed time after running `WaitForGameReady` and `ResetServerCall`.  It probably should, but 30s isn't enough at that point.