### PR TITLE
Kartridge support 

### DIFF
--- a/ICScriptHub.ahk
+++ b/ICScriptHub.ahk
@@ -69,6 +69,8 @@ if ( g_UserSettings[ "WindowYPositon" ] == "" )
     g_UserSettings[ "WindowYPositon" ] := 0
 if ( g_UserSettings[ "NoCtrlKeypress" ] == "" )
     g_UserSettings[ "NoCtrlKeypress" ] := 0
+if ( g_UserSettings[ "WaitForProcessTime" ] == "" )
+    g_UserSettings[ "WaitForProcessTime" ] := 0
 if(g_UserSettings[ "WriteSettings" ] := true)
 {
     g_UserSettings.Delete("WriteSettings")

--- a/SharedFunctions/IC_SharedFunctions_Class.ahk
+++ b/SharedFunctions/IC_SharedFunctions_Class.ahk
@@ -51,9 +51,9 @@ class IC_SharedData_Class
 
 class StackFailStates
 {
-    ; StackFail Types: 
+    ; StackFail Types:
     ; 1.  Ran out of stacks when ( > min stack zone AND < target stack zone). only reported when fail recovery is on
-    ;       Will stack farm - only a warning. Configuration likely incorrect            
+    ;       Will stack farm - only a warning. Configuration likely incorrect
     ; 2.  Failed stack conversion (Haste <= 50, SB > target stacks). Forced Reset
     ; 3.  Game was stuck (checkifstuck), forced reset
     ; 4.  Ran out of haste and steelbones > target, forced reset
@@ -598,7 +598,7 @@ class IC_SharedFunctions_Class
         if (settings[ "AvoidBosses" ] AND !Mod( this.Memory.ReadCurrentZone(), 5 ))
             return false
         ;unbench briv if 'Briv Jump Buffer' setting is disabled and transition direction is "OnFromLeft"
-        if (!(settings[ "BrivJumpBuffer" ]) AND this.Memory.ReadFormationTransitionDir() == 0) 
+        if (!(settings[ "BrivJumpBuffer" ]) AND this.Memory.ReadFormationTransitionDir() == 0)
             return true
         ;perform no other checks if 'Briv Jump Buffer' setting is disabled
         else if !(settings[ "BrivJumpBuffer" ])
@@ -642,6 +642,7 @@ class IC_SharedFunctions_Class
     {
         loadingDone := false
         g_SharedData.LoopString := "Starting Game"
+        waitForProcessTime := g_UserSettings[ "WaitForProcessTime" ]
         while ( !loadingZone AND ElapsedTime < 32000 )
         {
             this.Hwnd := 0
@@ -653,6 +654,7 @@ class IC_SharedFunctions_Class
                 g_SharedData.LoopString := "Opening IC.."
                 programLoc := g_UserSettings[ "InstallPath" ] . g_UserSettings ["ExeName" ]
                 Run, %programLoc%
+                Sleep, %waitForProcessTime%
                 while(ElapsedTime < 10000 AND !this.PID )
                 {
                     ElapsedTime := A_TickCount - StartTime
@@ -978,7 +980,7 @@ class IC_SharedFunctions_Class
         }
         return formation
     }
-    
+
     ; Tests if there is an adventure (objective) loaded. If not, asks the user to verify they are using the correct memory files and have an adventure loaded
     ; Returns -1 if failed to load adventure id. Returns current adventure's ID if successful in finding adventure.
     VerifyAdventureLoaded()


### PR DESCRIPTION
Adds a hidden setting, `WaitForProcessTime`, which is used to wait for a specified amount of time between launching the game process and checking for its PID. This is necessary when using the Kartridge client because the PID for IdleDragons.exe changes a few seconds after launch, seemingly when Kartridge hooks into it. Without this, the script gets stuck "waiting for game started" during stack restarts. I have found that a value of 5000 is *usually* sufficient, but I personally use 15000 because it takes at least that long before the scripts is able to read anything useful from memory anyway (of course this will vary somewhat between machines). Point being, I think it would be safe to set the value to probably even 10000 by default so that Kartridge people don't have to worry about it, since it's highly likely it will be at least 10s on any platform between process launch and calculating offline earnings.