### PR TITLE
Fixed empty slot in formation issues

### DIFF
--- a/SharedFunctions/IC_SharedFunctions_Class.ahk
+++ b/SharedFunctions/IC_SharedFunctions_Class.ahk
@@ -1059,7 +1059,7 @@ class IC_SharedFunctions_Class
         Fkeys := {}
         for k, v in formation
         {
-            if ( v != -1 )
+            if ( v != -1 AND this.Memory.ReadChampSeatByID(v) != "")
             {
                 Fkeys.Push("{F" . this.Memory.ReadChampSeatByID(v) . "}")
             }


### PR DESCRIPTION
Empty slots in the formation cause the key "F" to be input. 
This occurred in Trials of Mount Tiamat when escort takes up a formation slot