### PR TITLE
Fix recovery stack farming getting stuck when using manually configured target stacks

### DIFF
--- a/AddOns/IC_BrivGemFarm_Performance/IC_BrivGemFarm_Functions.ahk
+++ b/AddOns/IC_BrivGemFarm_Performance/IC_BrivGemFarm_Functions.ahk
@@ -296,7 +296,7 @@ class IC_BrivGemFarm_Class
             return 0
         }
         ; stack briv between min zone and stack zone if briv is out of jumps (if stack fail recovery is on)
-        if (g_SF.Memory.ReadHasteStacks() < 50 AND g_SF.Memory.ReadSBStacks() < targetStacks AND CurrentZone >= g_BrivUserSettings[ "MinStackZone" ] AND g_BrivUserSettings[ "StackFailRecovery" ] AND CurrentZone < g_BrivUserSettings[ "StackZone" ] )
+        if (g_SF.Memory.ReadHasteStacks() < 50 AND stacks < targetStacks AND CurrentZone >= g_BrivUserSettings[ "MinStackZone" ] AND g_BrivUserSettings[ "StackFailRecovery" ] AND CurrentZone < g_BrivUserSettings[ "StackZone" ] )
         {
             ; only use current zone if there's been no/non-excess issues with it.
             if (!this.StackFailAreasThisRunTally[CurrentZone] AND (!this.StackFailAreasTally[CurrentZone] OR this.StackFailAreasTally[CurrentZone] < this.MaxStackRestartFails))

--- a/AddOns/IC_BrivGemFarm_Performance/IC_BrivGemFarm_Functions.ahk
+++ b/AddOns/IC_BrivGemFarm_Performance/IC_BrivGemFarm_Functions.ahk
@@ -309,7 +309,7 @@ class IC_BrivGemFarm_Class
             return 0
         }
         ; Briv ran out of jumps but has enough stacks for a new adventure, restart adventure. With protections from repeating too early or resetting within 5 zones of a reset.
-        if (g_SF.Memory.ReadHasteStacks() < 50 AND stacks > targetStacks AND g_SF.Memory.ReadHighestZone() > 10 AND (g_SF.Memory.GetModronResetArea() - g_SF.Memory.ReadHighestZone() > 5 ))
+        if (g_SF.Memory.ReadHasteStacks() < 50 AND stacks >= targetStacks AND g_SF.Memory.ReadHighestZone() > 10 AND (g_SF.Memory.GetModronResetArea() - g_SF.Memory.ReadHighestZone() > 5 ))
         {
             stackFail := StackFailStates.FAILED_TO_REACH_STACK_ZONE_HARD ; 4
             g_SharedData.StackFailStats.TALLY[stackfail] += 1
@@ -318,7 +318,7 @@ class IC_BrivGemFarm_Class
         }
         ; stacks are more than the target stacks and party is more than "ResetZoneBuffer" levels past stack zone, restart adventure
         ; (for restarting after stacking without going to modron reset level)
-        if (stacks > targetStacks AND CurrentZone > g_BrivUserSettings[ "StackZone" ] + g_BrivUserSettings["ResetZoneBuffer"])
+        if (stacks >= targetStacks AND CurrentZone > g_BrivUserSettings[ "StackZone" ] + g_BrivUserSettings["ResetZoneBuffer"])
         {
             stackFail := StackFailStates.FAILED_TO_RESET_MODRON ; 6
             g_SharedData.StackFailStats.TALLY[stackfail] += 1


### PR DESCRIPTION
If `ReadSBStacks` is between `targetStacks - 47` and `targetStacks` then `TestForSteelBonesStackFarming` will call `StackFarm` again and again without any farming taking place.
When that happens `TestForSteelBonesStackFarming` will never be able to reach "enough stacks for a new adventure" either.

As a result the run keeps walking and `TALLY[FAILED_TO_REACH_STACK_ZONE]` keeps ticking up every 20ms (`GemFarm` loop sleep) until either modron or `CheckifStuck` triggers a restart.

Using manually configured target stacks, all other stack comparisons use `GetNumStacksFarmed` (via `stacks`)
Replacing `ReadSBStacks` with `stacks` should fix this.