### PR TITLE
Bug in IC_Addon_Management_Functions.ahk\GetAddonManagementSettings()

### DIFF
--- a/AddOns/IC_Addon_Management/IC_Addon_Management_Functions.ahk
+++ b/AddOns/IC_Addon_Management/IC_Addon_Management_Functions.ahk
@@ -316,14 +316,10 @@ Class AddonManagement
         }
         ; here we will enable all addons that needed to be added
         AddonSettings:= g_SF.LoadObjectFromJSON(this.AddonManagementConfigFile)
-        for k,v in AddonSettings {
-            if (k = "Addon Order"){
-                this.AddonOrder := v
-            }
-            else {
-                if (v.Enabled){
-                    this.EnableAddon(k,v.Version)
-                }     
+        this.AddonOrder := AddonSettings["Addon Order"]
+        for k, v in this.AddonOrder {
+            if (AddonSettings[v.Name].Enabled){
+                this.EnableAddon(v.Name,v.Version)
             }
         }
 


### PR DESCRIPTION
Came across this issue back when I tried to fill dependencies for AreaTiming addon, now again because of a typo in my future swap feats addon.
When called, GetAddonManagementSettings() doesn't enable addons in the correct saved order and will try to enable addons in alphabetical order instead. E.g. "Area Timing" comes before "Briv Gem Farm". I had to remove it from being a dependency as a temporary fix.
Furthermore, an addon with a dict name preceding "Addon Order" will also be enabled before any other addon present in "Addon Order".