### PR TITLE
Addon management addon issues

### DIFF
--- a/AddOns/IC_Addon_Management/IC_Addon_Management_Functions.ahk
+++ b/AddOns/IC_Addon_Management/IC_Addon_Management_Functions.ahk
@@ -174,8 +174,8 @@ Class AddonManagement
     CheckDependencieOrder(AddonNumber,PositionWanted){
         if(AddonNumber > PositionWanted){
             ; moving Up
-            LoopCounter:=PositionWanted
             for k, v in this.Addons[AddonNumber]["Dependencies"]{
+                LoopCounter:=PositionWanted
                 while(LoopCounter<AddonNumber){
                     if(v.Name=this.Addons[Loopcounter]["Name"] AND IC_VersionHelper_class.IsVersionSameOrNewer(this.Addons[Loopcounter]["Version"], v.Version)){
                         Return Loopcounter

--- a/AddOns/IC_Addon_Management/IC_Addon_Management_Functions.ahk
+++ b/AddOns/IC_Addon_Management/IC_Addon_Management_Functions.ahk
@@ -317,9 +317,18 @@ Class AddonManagement
         ; here we will enable all addons that needed to be added
         AddonSettings:= g_SF.LoadObjectFromJSON(this.AddonManagementConfigFile)
         this.AddonOrder := AddonSettings["Addon Order"]
-        for k, v in this.AddonOrder {
-            if (AddonSettings[v.Name].Enabled){
-                this.EnableAddon(v.Name,v.Version)
+        if (IsObject(this.AddonOrder)){
+            for k, v in this.AddonOrder {
+                if (AddonSettings[v.Name].Enabled){
+                    this.EnableAddon(v.Name,v.Version)
+                }
+            }
+        }
+        else{
+            for k,v in AddonSettings {
+                if (v.Enabled){
+                    this.EnableAddon(k,v.Version)
+                }
             }
         }
 


### PR DESCRIPTION
To follow up the last issue with the Addon Management addon, here's a couple more issues.

First one: `Briv Gem Farm` and` Game Location Settings` not being turned on by default on a new install (due to the previous fix to addon enabling order ).
Second one: only the first dependency specified in an addon's Addon.json file will be counted for moving up an addon above another.