### PR TITLE
Added check for g_SF.Memory.ReadCurrentZone() reading -1 in IC_BrivSharedFunctions_Class .WaitForModronreset()

### DIFF
--- a/AddOns/IC_BrivGemFarm_Performance/IC_BrivGemFarm_Functions.ahk
+++ b/AddOns/IC_BrivGemFarm_Performance/IC_BrivGemFarm_Functions.ahk
@@ -81,7 +81,7 @@ class IC_BrivSharedFunctions_Class extends IC_SharedFunctions_Class
         }
         g_SharedData.LoopString := "Loading z1..."
         Sleep, 50
-        while ( !this.Memory.ReadUserIsInited() AND g_SF.Memory.ReadCurrentZone() < 1 AND AND ElapsedTime < timeout )
+        while ( !this.Memory.ReadUserIsInited() AND g_SF.Memory.ReadCurrentZone() < 1 AND ElapsedTime < timeout )
         {
             ElapsedTime := A_TickCount - StartTime
             Sleep, 20

--- a/AddOns/IC_BrivGemFarm_Performance/IC_BrivGemFarm_Functions.ahk
+++ b/AddOns/IC_BrivGemFarm_Performance/IC_BrivGemFarm_Functions.ahk
@@ -81,7 +81,7 @@ class IC_BrivSharedFunctions_Class extends IC_SharedFunctions_Class
         }
         g_SharedData.LoopString := "Loading z1..."
         Sleep, 50
-        while ( !this.Memory.ReadUserIsInited() AND ElapsedTime < timeout )
+        while ( !this.Memory.ReadUserIsInited() AND g_SF.Memory.ReadCurrentZone() < 1 AND AND ElapsedTime < timeout )
         {
             ElapsedTime := A_TickCount - StartTime
             Sleep, 20


### PR DESCRIPTION
I made this modification a few months back to the LevelUp addon because several users had an issue with the script failing to wait on modron resetting properly. Would it be possible to add this to the main script?