### PR TITLE
Some edits to the Stats addon.

### DIFF
--- a/AddOns/IC_BrivGemFarm_Stats/Addon.json
+++ b/AddOns/IC_BrivGemFarm_Stats/Addon.json
@@ -1,6 +1,6 @@
 {
 	"Name":"Briv Gem Farm Stats",
-	"Version": "v1.1.3",
+	"Version": "v1.1.4",
     "Includes" : "IC_BrivGemFarm_Stats_Component.ahk",
     "Author" : "Antilectual",
     "Url" : "https://github.com/mikebaldi/Idle-Champions/tree/main/AddOns/IC_BrivGemFarm_Stats",

--- a/AddOns/IC_BrivGemFarm_Stats/IC_BrivGemFarm_Stats_Functions.ahk
+++ b/AddOns/IC_BrivGemFarm_Stats/IC_BrivGemFarm_Stats_Functions.ahk
@@ -170,7 +170,7 @@ class IC_BrivGemFarm_Stats_Component
         posX += 70
         Gui, ICScriptHub:Add, Text, vNordomWarningID x%posX% y%posY% w260,
         GuiControlGet, pos, ICScriptHub:Pos, GemsTotalID
-        posX += 70
+        posX += 90
         Gui, ICScriptHub:Add, Text, vGemsSpentWarningID x%posX% y%posY% w260,
         GuiControlGet, pos, ICScriptHub:Pos, OnceRunGroupID
         g_DownAlign := g_DownAlign + posH -5

--- a/AddOns/IC_BrivGemFarm_Stats/IC_BrivGemFarm_Stats_Functions.ahk
+++ b/AddOns/IC_BrivGemFarm_Stats/IC_BrivGemFarm_Stats_Functions.ahk
@@ -396,8 +396,8 @@ class IC_BrivGemFarm_Stats_Component
                     this.BossesPerHour := Round( ( ( currentCoreXP - this.CoreXPStart + ( this.NordomXPStart - currentNordomXP ) ) / 5 ) / dtTotalTime, 2 )
                 else if(currentCoreXP)
                     this.BossesPerHour := Round( ( ( currentCoreXP - this.CoreXPStart ) / 5 ) / dtTotalTime, 2 )
-                GuiControl, ICScriptHub:, bossesPhrID, % this.BossesPerHour
             }
+            GuiControl, ICScriptHub:, bossesPhrID, % this.BossesPerHour
             
             statsGemsSpent := g_SF.Memory.ReadGemsSpent()
             if (statsGemsSpent == 2147483647)


### PR DESCRIPTION
Few edits in this. I don't know if the way I've made them is the best way of doing them - but they appear to work. 🤷‍♀️

### Counter for hybrid stacking
Added a counter to the bottom of the stats addon (just under Calculated Target Stacks) for when running hybrid stacking - to know at a glance what the current run counter is. It won't display if ForceOfflineRunThreshold is 0. (Now that I think about it - it should only display if it's >1.)

### Max Integer Stats
First I've added support for estimating the `Total Gems` and `Gems per hour` for when the Gems Spent stat is capped at maximum integer.
And secondly I've added support for estimating the `Bosses per hour` stat for when the Modron XP is capped at maximum integer. (For this I've co-opted the Nordom warning for displaying that it's estimating.)
I think I did the maths correctly. I might not have. 🤷‍♀️

![image](https://github.com/mikebaldi/Idle-Champions/assets/87337611/51de85e0-b1d3-47c9-ba1b-a03265a2e7c0)