### PR TITLE
Refactor to avoid g_SF.Memory.ReadGemsSpent()

### DIFF
--- a/AddOns/IC_BrivGemFarm_Performance/IC_BrivGemFarm_Functions.ahk
+++ b/AddOns/IC_BrivGemFarm_Performance/IC_BrivGemFarm_Functions.ahk
@@ -888,6 +888,7 @@ class IC_BrivGemFarm_Class
                 {
                     g_SharedData.PurchasedSilverChests += chestID == 1 ? numChests : 0
                     g_SharedData.PurchasedGoldChests += chestID == 2 ? numChests : 0
+                    g_SharedData.GemsSpent += numChests * (chestID == 1 ? 50 : 500)
                     g_SF.TotalSilverChests := (chestID == 1) ? response.chest_count : g_SF.TotalSilverChests
                     g_SF.TotalGoldChests := (chestID == 2) ? response.chest_count : g_SF.TotalGoldChests
                     g_SF.TotalGems := response.currency_remaining

--- a/AddOns/IC_BrivGemFarm_Stats/IC_BrivGemFarm_Stats_Functions.ahk
+++ b/AddOns/IC_BrivGemFarm_Stats/IC_BrivGemFarm_Stats_Functions.ahk
@@ -13,6 +13,7 @@ class IC_BrivGemFarm_Stats_Component
     CoreXPStart := 0
     NordomXPStart := 0
     GemStart := 0
+    CurrentGemsSpent := 0
     GemSpentStart := 0
     BossesPerHour := 0
     LastResetCount := 0
@@ -324,7 +325,9 @@ class IC_BrivGemFarm_Stats_Component
                 this.CoreXPStart := g_SF.Memory.GetCoreXPByInstance(this.ActiveGameInstance)
                 this.NordomXPStart := ActiveEffectKeySharedFunctions.Nordom.NordomModronCoreToolboxHandler.ReadAwardedXPStat()
                 this.GemStart := g_SF.Memory.ReadGems()
-                this.GemSpentStart := g_SF.Memory.ReadGemsSpent()
+                this.GemSpentStart := 0
+                if (IsObject(this.SharedRunData))
+                    this.GemSpentStart := this.SharedRunData.GemsSpent
                 this.LastResetCount := g_SF.Memory.ReadResetsCount()
                 silverChests := g_SF.Memory.ReadChestCountByID(1)
                 goldChests := g_SF.Memory.ReadChestCountByID(2)
@@ -399,7 +402,10 @@ class IC_BrivGemFarm_Stats_Component
                 this.bossesPerHour := Round( (xpGain / 5) / dtTotalTime, 2)
             GuiControl, ICScriptHub:, bossesPhrID, % this.BossesPerHour
 
-            this.GemsTotal := ( g_SF.Memory.ReadGems() - this.GemStart ) + ( g_SF.Memory.ReadGemsSpent() - this.GemSpentStart )
+            this.CurrentGemsSpent := 0
+            if (IsObject(this.SharedRunData))
+                this.CurrentGemsSpent := this.SharedRunData.GemsSpent
+            this.GemsTotal := ( g_SF.Memory.ReadGems() - this.GemStart ) + ( this.CurrentGemsSpent - this.GemSpentStart )
             GuiControl, ICScriptHub:, GemsTotalID, % this.GemsTotal
             GuiControl, ICScriptHub:, GemsPhrID, % Round( this.GemsTotal / dtTotalTime, 2 )
 
@@ -524,6 +530,7 @@ class IC_BrivGemFarm_Stats_Component
             SharedRunData.OpenedGoldChests := 0
             SharedRunData.PurchasedGoldChests := 0
             SharedRunData.PurchasedSilverChests := 0
+            SharedRunData.GemsSpent := 0
             SharedRunData.ShinyCount := 0
             SharedRunData.TotalRollBacks := 0
             SharedRunData.BadAutoProgress := 0

--- a/AddOns/IC_BrivGemFarm_Stats/IC_BrivGemFarm_Stats_Functions.ahk
+++ b/AddOns/IC_BrivGemFarm_Stats/IC_BrivGemFarm_Stats_Functions.ahk
@@ -595,6 +595,7 @@ class IC_BrivGemFarm_Stats_Component
         this.NordomXPStart := 0
         this.GemStart := 0
         this.GemSpentStart := 0
+        this.CurrentGemsSpent := 0
         this.BossesPerHour := 0
         this.LastResetCount := 0
         this.RunStartTime := A_TickCount

--- a/AddOns/IC_Core/IC_SharedFunctions_Class.ahk
+++ b/AddOns/IC_Core/IC_SharedFunctions_Class.ahk
@@ -27,6 +27,7 @@ class IC_SharedData_Class
     OpenedGoldChests := 0
     PurchasedGoldChests := 0
     PurchasedSilverChests := 0
+    GemsSpent := 0
     ShinyCount := 0
     TriggerStart := false
     TotalRollBacks := 0

--- a/Addons.md
+++ b/Addons.md
@@ -13,6 +13,7 @@ Script Hub uses an addon system to add/update functionality. Developers can writ
 [AzakaQWE](https://github.com/Fedvee/IC-addons/tree/main/IC_AzakaQWE_Extra) by Fedv  
 [Better Azaka](https://github.com/Pneumatus/IC-Addons/tree/main/IC_BetterAzaka_Extra) by Ismo  
 [BrivGemFarm BrivFeatSwap](https://github.com/imp444/IC_Addons/tree/main/IC_BrivGemFarm_BrivFeatSwap_Extra) by ImpEGamer  
+[BrivGemFarm HideDefaultProfile](https://github.com/Emmotes/IC_Addons/tree/main/IC_Addons/IC_BrivGemFarm_HideDefaultProfile_Extra) by Emmote  
 [BrivGemFarm HybridTurboStacking](https://github.com/imp444/IC_Addons/tree/main/IC_BrivGemFarm_HybridTurboStacking_Extra) by ImpEGamer  
 [BrivGemFarm LevelUp](https://github.com/imp444/IC_Addons/tree/main/IC_BrivGemFarm_LevelUp_Extra) by ImpEGamer  
 [Close Welcome Back](https://github.com/Pneumatus/IC-Addons/tree/main/IC_BrivGemFarm_CloseWelcomeBack_Extra) by Ismo  


### PR DESCRIPTION
Some of us have gotten capped Gems Spent stats and so the Stats addon can no longer have accurate gems stats if we buy chests.

This is just an example workaround I've thrown together where the script keeps track of the gems it has spent on chests itself.

It's a bit hacky - so I don't know if this is how you would want it implemented - or if you'll maybe want to edit it so it only does this when ReadGemsSpent() is at capped Int?

(I'm not even sure if this method is actually working. I've tested it but Ellywick is so RNG that the numbers could be wrong and I wouldn't know.)