### PR TITLE
Adding support for Briv's Thunder Step feat.

### DIFF
--- a/AddOns/IC_BrivGemFarm_Performance/Addon.json
+++ b/AddOns/IC_BrivGemFarm_Performance/Addon.json
@@ -1,6 +1,6 @@
 {
 	"Name":"Briv Gem Farm",
-	"Version": "v1.4.7",
+	"Version": "v1.4.8",
     "Includes" : "IC_BrivGemFarm_Component.ahk",
     "Author" : "Antilectual & mikebaldi1980",
     "Url" : "https://github.com/mikebaldi/Idle-Champions/tree/main/AddOns/IC_BrivGemFarm_Performance",

--- a/AddOns/IC_BrivGemFarm_Performance/IC_BrivGemFarm_Functions.ahk
+++ b/AddOns/IC_BrivGemFarm_Performance/IC_BrivGemFarm_Functions.ahk
@@ -40,6 +40,8 @@ class IC_BrivSharedFunctions_Class extends IC_SharedFunctions_Class
         this.TotalGoldChests := (goldChests != "") ? goldChests : this.TotalGoldChests
         this.sprint := this.Memory.ReadHasteStacks()
         this.steelbones := this.Memory.ReadSBStacks()
+        if (this.BrivHasThunderStep())
+            this.steelbones := Floor(this.steelbones * 1.2)
     }
 
     ; sets the user information used in server calls such as user_id, hash, active modron, etc.
@@ -159,6 +161,26 @@ class IC_BrivSharedFunctions_Class extends IC_SharedFunctions_Class
         }
         g_PreviousZoneStartTime := A_TickCount
         return
+    }
+    
+    BrivHasThunderStep() ;Thunder step 'Gain 20% More Sprint Stacks When Converted from Steelbones', feat 2131.
+    {
+        If (g_SF.Memory.HeroHasAnyFeatsSavedInFormation(58, g_SF.Memory.GetSavedFormationSlotByFavorite(1)) OR g_SF.Memory.HeroHasAnyFeatsSavedInFormation(58, g_SF.Memory.GetSavedFormationSlotByFavorite(3))) ;If there are feats saved in Q or E (which would overwrite any others in M)
+        {
+            thunderInQ := g_SF.Memory.HeroHasFeatSavedInFormation(58, 2131, g_SF.Memory.GetSavedFormationSlotByFavorite(1))
+            thunderInE := g_SF.Memory.HeroHasFeatSavedInFormation(58, 2131, g_SF.Memory.GetSavedFormationSlotByFavorite(3))
+            return (thunderInQ OR thunderInE)
+        }
+        else if (g_SF.Memory.HeroHasFeatSavedInFormation(58, 2131, g_SF.Memory.GetActiveModronFormationSaveSlot()))
+            return true
+		else
+		{
+			feats := g_SF.Memory.GetHeroFeats(58)
+			for k, v in feats
+				if (v == 2131)
+					return true
+		}
+		return false
     }
 }
 

--- a/AddOns/IC_Core/MemoryRead/IC_MemoryFunctions_Class.ahk
+++ b/AddOns/IC_Core/MemoryRead/IC_MemoryFunctions_Class.ahk
@@ -66,7 +66,7 @@ class IC_MemoryFunctions_Class
     ;Updates installed after the date of this script may result in the pointer addresses no longer being accurate.
     GetVersion()
     {
-        return "v2.4.8, 2024-08-17"
+        return "v2.4.9, 2025-07-16"
     }
 
     GetPointersVersion()
@@ -1216,6 +1216,45 @@ class IC_MemoryFunctions_Class
     {
         version := !_MemoryManager.is64Bit ? ( (g_ImportsGameVersion32 == "" ? " ---- " : (g_ImportsGameVersion32 . g_ImportsGameVersionPostFix32 )) . " (32 bit), " ) : ( (g_ImportsGameVersion64 == "" ? " ---- " : (g_ImportsGameVersion64 . g_ImportsGameVersionPostFix64)) . " (64 bit)")
         return version
+    }
+    
+    HeroHasFeatSavedInFormation(heroID, featID, formationSlot)
+    {
+        size := this.GameManager.game.gameInstances[this.GameInstance].FormationSaveHandler.formationSavesV2[formationSlot].Feats[heroID].List.size.Read()
+        if(size <= 0 OR size > 10) ; sanity check, should be < 6 but set to 10 in case of future game field familiar increase.
+            return false
+        Loop, %size%
+        {
+            value := this.GameManager.game.gameInstances[this.GameInstance].FormationSaveHandler.formationSavesV2[formationSlot].Feats[heroID].List[A_Index - 1].Read()
+            if (value==featID)
+                return true
+        }
+        return false
+    }
+    
+    HeroHasAnyFeatsSavedInFormation(heroID, formationSlot)
+    {
+        size := this.GameManager.game.gameInstances[this.GameInstance].FormationSaveHandler.formationSavesV2[formationSlot].Feats[heroID].List.size.Read()
+        if(size <= 0 OR size > 10) ; sanity check, should be < 6 but set to 10 in case of future game field familiar increase.
+            return false
+        return true
+    }
+
+    GetHeroFeats(heroID)
+    {
+        if (heroID < 1)
+            return ""
+        size := g_SF.Memory.GameManager.game.gameInstances[g_SF.Memory.GameInstance].Controller.userData.FeatHandler.heroFeatSlots[heroID].List.size.Read()
+        ; Sanity check, should be < 4 but set to 10 in case of future feat num increase.
+        if (size < 0 || size > 10)
+            return ""
+        featList := []
+        Loop, %size%
+        {
+            value := g_SF.Memory.GameManager.game.gameInstances[g_SF.Memory.GameInstance].Controller.userData.FeatHandler.heroFeatSlots[heroID].List[A_Index - 1].ID.Read()
+            featList.Push(value)
+        }
+        return featList
     }
 
     #include *i %A_LineFile%\..\IC_MemoryFunctions_Extended.ahk


### PR DESCRIPTION
Thunder Step increases Briv's earned stacks during conversion by 1.2x (rounded down) - but this does not happen when the script restarts.

So - adding a way of checking if Briv has the feat equipped and if so - doing the multiplication so that `CallPreventStackFail` will apply it. Otherwise it risks a doom-loop.

Adding some MemoryFunctions methods:
- HeroHasFeatSavedInFormation
- HeroHasAnyFeatsSavedInFormation
- GetHeroFeats

And adding a method that uses them to BrivGemFarm_Performance:
- BrivHasThunderStep

Code is mostly supplied by Irisiri and ImpEGamer - I just put it together and modified it slightly and tested it.